### PR TITLE
Use Github Actions as CI for Linux x86_64 and aarch64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake ..
+        make shared
+
+  build-aarch64:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      uses: uraimo/run-on-arch-action@v2
+      with:
+        arch: aarch64
+        distro: ubuntu20.04
+        githubToken: ${{ github.token }}
+        dockerRunArgs: |
+          --volume "${PWD}:/paw"
+        install: |
+          apt-get update -q -y
+          apt-get install -q -y gcc g++ make cmake libboost-all-dev
+        run: |
+          cd /paw
+          echo "Building..."
+          mkdir build
+          cd build
+          cmake ..
+          make shared

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ else()
 endif()
 
 ## Setup other compiler flags
-set(CMAKE_CXX_FLAGS_COMMON "${CMAKE_CXX_FLAGS_COMMON} -Wall -Wextra -Wfatal-errors -m64 -march=x86-64 -mtune=generic")
+set(CMAKE_CXX_FLAGS_COMMON "${CMAKE_CXX_FLAGS_COMMON} -Wall -Wextra -Wfatal-errors -march=native -mtune=generic")
 
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -DPAW_BUILD ${CMAKE_CXX_FLAGS_COMMON} -pedantic -DDEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE "-g -O3 -DPAW_BUILD ${CMAKE_CXX_FLAGS_COMMON} -DNDEBUG")


### PR DESCRIPTION
Remove '-m64' CXX flag. It is implicit for x86_64. 
Change '-march=' to 'native', so that it can build for aarch64 too
